### PR TITLE
Improve support for slide advancers as e-stop devices

### DIFF
--- a/docs/implementations/luci.md
+++ b/docs/implementations/luci.md
@@ -13,6 +13,8 @@ LUCI implements the WDI for USB and will be compatible with Bluetooth in the fut
 | Silence sounds | None | BTN_NORTH |
 | Reset changes | Home | None |
 | Profile decrement | matches main spec | ABS_HAT0Y = 1 (temporarily implemented until mode switching is implemented) |
+| Power/Sleep toggle | None (Escape temporarily mapped to emergency stop until power controls implemented) | None |
+| Switch mode | None (Tab temporarily mapped to emergency stop until mode controls implemented) | None |
 
 ## Limitations and Known Issues
 ### General

--- a/docs/usb/wdi-usb-interface.md
+++ b/docs/usb/wdi-usb-interface.md
@@ -69,7 +69,7 @@ Since what needs to be controlled varies depending on the WDI [implementation](.
 | Drive backward | 's' \| down arrow | Y axis (towards max val) |
 | Drive left | 'a' \| left arrow | X axis (towards min val) |
 | Drive right | 'd' \| right arrow | X axis (towards max val) |
-| Emergency stop | backspace \| page up \| page down | BTN_SOUTH |
+| Emergency stop | page up \| page down \| 'b' \| 'SHIFT + F5 | BTN_SOUTH |
 | Device control toggle | enter | BTN_START |
 | Enable device control | None | BTN_C |
 | Disable device control | None | BTN_MODE |
@@ -87,8 +87,8 @@ User menu control matches drive controls.
 | Switch mode | tab | d-pad down (ABS_HAT0Y = 1) |
 | Headlight toggle | 'l' | BTN_THUMBL |
 | Hazard lights | 'h' | BTN_WEST |
-| Left blinker | 'b' | d-pad left(ABS_HAT0X = -1) |
-| Right blinker | 'n' | d-pad right(ABS_HAT0X = 1) |
+| Left blinker | '<' \| SHIFT + comma | d-pad left(ABS_HAT0X = -1) |
+| Right blinker | '>' \| SHIFT + period | d-pad right(ABS_HAT0X = 1) |
 | Horn | spacebar (while pressed) | BTN_THUMBR (while pressed) |
 
 ### Seating


### PR DESCRIPTION
**Why the Change**
Based on testing with half a dozen slide advancers, many have 2-function page up and page down buttons. So that the second function happens when the button is held down (like you would if you were worried and mashing an e-stop for example). These second functions send SHIFT + F5 and 'b' commands which map to start presentation and blank screen in PowerPoint. 

**What the Change**
- Added 'b' and SHIFT + F5 to accepted e-stop commands
- Remapped turn signals to clear 'b'
- Removed backspace from e-stop command