### PR TITLE
Update seating controls and LUCI impl notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Wheelchair Digital Interface (WDI) API detailed in this project is a modern,
 The purpose of the open WDI standard is: 
 1. to allow faster development of new accessible wheelchair alternative controls by removing the need for 9-pin printer cable adapter circuits currently required to adapt to today's proprietary TRACE/DB-9 alternative drive inputs, 
 2. to make current, commercially available adaptive gaming and computer interfaces available to power wheelchair users, and, 
-3. to allow two-direction commumication between the power wheelchair and the controller. 
+3. to allow two-direction communication between the power wheelchair and the controller. 
 
 ## Background
 The WDI was initially conceived and developed as part of the National Science Foundation (NSF) Convergence Accelerator Track H project "Mobility Independence through Accelerated Wheelchair Intelligence" (NSF SP0076554) with input from a wide range of stakeholders. 
@@ -83,8 +83,9 @@ The specific actuators that can be adjusted up and down are:
 * Legs
 * Elevate
 * Footplates
+* Stand
 
-In addition to the specific actuators, chairs may be programmed with a number of set positions that the seating system can be automatically positioned to.
+In addition to the specific actuators, chairs may be programmed with a number of set positions (i.e. memory positions) that the seating system can be automatically positioned to.
 
 ## Future Needs:
 * Override a system behavior

--- a/docs/implementations/luci.md
+++ b/docs/implementations/luci.md
@@ -10,7 +10,6 @@ LUCI implements the WDI for USB and will be compatible with Bluetooth in the fut
 | Action | Keyboard | Gamepad |
 |-----|---|---|
 | Override | caps lock | BTN_EAST |
-| Silence sounds | None | BTN_NORTH |
 | Reset changes | Home | None |
 | Profile decrement | matches main spec | ABS_HAT0Y = 1 (temporarily implemented until mode switching is implemented) |
 | Power/Sleep toggle | None (Escape temporarily mapped to emergency stop until power controls implemented) | None |
@@ -19,13 +18,14 @@ LUCI implements the WDI for USB and will be compatible with Bluetooth in the fut
 ## Limitations and Known Issues
 ### General
 1. LUCI turns off when the wheelchair does, so an input device cannot be used to turn the chair on through LUCI. This also means devices powered through the USB connection to LUCI are off when LUCI is off.
-1. Seating position cannot be moved using the input device through LUCI.
+1. Seating position cannot be moved using the drive commands on the input device through LUCI (on most existing chairs).
+1. The mapping of HID commands to seating axis is not consistent across chair manufacturers. It should match on Permobil chairs. On other chairs, all axes should be accessible through the same WDI commands, but may not line up with the mapping exactly. Additionally, numpad 5-9 are also mapped to potential seating axes seen on other chair models and can be used the same way (SHIFT up, CTRL down).
 1. User menu cannot be navigated using the input device through LUCI.
 1. Speed setting adjustments made by LUCI are not remembered by the wheelchair electronics. This means that the previously set speed setting will come back if the profile is changed or the the chair is rebooted, and that any changes made to speed setting through the normal joystick interface will change based on what the speed setting was before LUCI changed it (e.g. speed 5 -> LUCI changes to speed 1 -> speed setting decrease through JSM leads to speed 4).
 1. LUCI does not know how many profiles are enabled on the chair and currently assumes there are 4. On chairs with fewer than 4, incrementing to a disabled profile is a no-op on the chair, and incrementing continues to be no-ops until wrapping back around to profile 1. On chairs with more than 4 enabled profiles, there is no way to access the additional profiles via the WDI currently.
 
 ### Chairs with Tracking (ESP)
-This includes most modern Permobil chairs. These issues occur only when the chair is being controlled via the WDI.
+This includes most Permobil chairs made between 2020-2024 (before Power Platform). These issues occur only when the chair is being controlled via the WDI.
 1. Programmed RNET settings do not affect drive behavior.
 1. Speed settings 4 and 5 do not affect drive behavior and are functionally equivalent to speed 3.
 1. Profile does not affect drive behavior.

--- a/docs/usb/wdi-usb-interface.md
+++ b/docs/usb/wdi-usb-interface.md
@@ -92,17 +92,18 @@ User menu control matches drive controls.
 | Horn | spacebar (while pressed) | BTN_THUMBR (while pressed) |
 
 ### Seating
-Seating can be controlled using the drive controls when in seating adjust mode. Alternatively, the following actions are mapped to specific inputs. For now, the gamepad mapping uses buttons outside the range of typical usage, but a mapping such that off-the-shelf gamepads are usable will be created too.
+Seating can be controlled using the drive controls when in seating adjust mode. Alternatively, the following actions are mapped to specific inputs. The seating axis will move as long as the corresponding button is held down and will stop moving when released. For now, the gamepad mapping uses buttons outside the range of typical usage, but a mapping such that off-the-shelf gamepads are usable will be created too.
 
 | Action | Keyboard Controls | Gamepad Controls |
 |--------|------|-----|
-| Memory seating 1 forward | SHIFT + 1 | BTN_TRIGGER_HAPPY1 |
-| Memory seating 1 backward | CTRL + 1 | BTN_TRIGGER_HAPPY2 |
-| Memory seating 2 forward | SHIFT + 2 | BTN_TRIGGER_HAPPY3 |
-| Memory seating 2 backward | CTRL + 2 | BTN_TRIGGER_HAPPY4 |
-| Memory seating 3 forward | SHIFT + 3 | BTN_TRIGGER_HAPPY5 |
-| Memory seating 3 backward | CTRL + 3 | BTN_TRIGGER_HAPPY6 |
-| Tilt forward | SHIFT + numpad 0 | BTN_TRIGGER_HAPP7 |
+| Memory seating 1    | F1 | BTN_TRIGGER_HAPPY1 |
+| Memory seating 2    | F2 | BTN_TRIGGER_HAPPY2 |
+| Memory seating 3    | F3 | BTN_TRIGGER_HAPPY3 |
+| Memory seating 4    | F4 | BTN_TRIGGER_HAPPY4 |
+| Memory seating 5    | F5 | BTN_TRIGGER_HAPPY5 |
+| Memory seating 6    | F6 | BTN_TRIGGER_HAPPY6 |
+| Memory seating Home | F7 | BTN_TRIGGER_HAPPY19 |
+| Tilt forward | SHIFT + numpad 0 | BTN_TRIGGER_HAPPY7 |
 | Tilt backward | CTRL + numpad 0 | BTN_TRIGGER_HAPPY8 |
 | Recline forward | SHIFT + numpad 1 | BTN_TRIGGER_HAPPY9 |
 | Recline backward | CTRL + numpad 1 | BTN_TRIGGER_HAPPY10 |
@@ -112,3 +113,7 @@ Seating can be controlled using the drive controls when in seating adjust mode. 
 | Elevate down | CTRL + numpad 3 | BTN_TRIGGER_HAPPY14 |
 | Legrest retract | SHIFT + numpad 4 | BTN_TRIGGER_HAPPY15 |
 | Legrest extend | CTRL + numpad 4 | BTN_TRIGGER_HAPPY16 |
+| Stand Up | SHIFT + numpad period | BTN_TRIGGER_HAPPY17 |
+| Stand Down | CTRL + numpad period | BTN_TRIGGER_HAPPY18 |
+
+There is currently no mapping for explicity saving a memory seating position. On existing chairs, this is possible to do using joystick movements, and so memory positions can be set using those same commands through the WDI.


### PR DESCRIPTION
When implementing seating controls, I found a few things that warranted updates here:
1. Memory seating control only moves in one direction and so doesn't need separate mappings for up and down.
2. Some chairs have more memory positions than the previously defined 3, so I used the now open mappings to fill in more memory positions.
3. Not all chairs use the same ID for the same seating axis, and so this first implementation on LUCI may have some of the mappings mixed up depending on chair manufacturer. It should match on Permobil chairs
4. A new power platform Permobil chair had a default "Home" memory position that didn't seem to be just a renamed memory 1, so I added that as a new option too.
5. LUCI is now available on many more chairs that have standing capability, so I figured it was worth adding.

